### PR TITLE
Fix config storage in CognitoIdentityService

### DIFF
--- a/src/common/aws/cognito-identity.service.ts
+++ b/src/common/aws/cognito-identity.service.ts
@@ -11,11 +11,12 @@ import { ConfigService } from '@nestjs/config';
 export class CognitoIdentityService {
   private readonly idp: CognitoIdentityClient;
   private readonly idPoolId: string;
-  private readonly cfg: ConfigService
+  private readonly cfg: ConfigService;
 
   constructor(cfg: ConfigService) {
-    this.idp       = new CognitoIdentityClient({ region: cfg.get('aws.region') });
-    this.idPoolId  = cfg.get<string>('cognito.identityPoolId')!;
+    this.cfg      = cfg;
+    this.idp      = new CognitoIdentityClient({ region: this.cfg.get('aws.region') });
+    this.idPoolId = this.cfg.get<string>('cognito.identityPoolId')!;
   }
 
   /** Exchange ID‑token for short‑lived AWS creds */


### PR DESCRIPTION
## Summary
- ensure the CognitoIdentityService keeps the provided ConfigService so `this.cfg` works consistently

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d4d966cc832b82e77c76383db098